### PR TITLE
Add suport for grouping parameters

### DIFF
--- a/src/main/java/de/jjohannes/gradle/buildparameters/BuildParameter.java
+++ b/src/main/java/de/jjohannes/gradle/buildparameters/BuildParameter.java
@@ -2,6 +2,7 @@ package de.jjohannes.gradle.buildparameters;
 
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 import javax.inject.Inject;
@@ -9,10 +10,12 @@ import javax.inject.Inject;
 public abstract class BuildParameter {
 
     private final String name;
+    private final String prefix;
 
     @Inject
-    public BuildParameter(String name) {
+    public BuildParameter(String name, String prefix) {
         this.name = name;
+        this.prefix = prefix;
     }
 
     @Input
@@ -20,10 +23,16 @@ public abstract class BuildParameter {
         return name;
     }
 
+    @Internal
+    public String getPath() {
+        return prefix.isEmpty() ? name : prefix + "." + name;
+    }
+
     @Input
     @Optional
     public abstract Property<String> getDefaultValue();
 
     @Input
+    @Optional
     public abstract Property<String> getDescription();
 }

--- a/src/main/java/de/jjohannes/gradle/buildparameters/BuildParameterGroup.java
+++ b/src/main/java/de/jjohannes/gradle/buildparameters/BuildParameterGroup.java
@@ -1,0 +1,65 @@
+package de.jjohannes.gradle.buildparameters;
+
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+
+import javax.inject.Inject;
+
+public abstract class BuildParameterGroup {
+
+    static final String BASE_GROUP_NAME = "buildParametersExtension";
+
+    private final String name;
+    private final String prefix;
+
+    @Inject
+    public BuildParameterGroup(String name, String prefix) {
+        this.name = name;
+        this.prefix = prefix;
+    }
+
+    public void parameter(String name, Action<? super BuildParameter> configure) {
+        String parameterPrefix = getPrefix();
+        BuildParameter parameter = getObjects().newInstance(BuildParameter.class, name, parameterPrefix);
+        configure.execute(parameter);
+        getParameters().add(parameter);
+    }
+
+    public void group(String name, Action<? super BuildParameterGroup> configure) {
+        String groupPrefix = getPrefix();
+        BuildParameterGroup group = getObjects().newInstance(BuildParameterGroup.class, name, groupPrefix);
+        configure.execute(group);
+        getGroups().add(group);
+    }
+
+    private String getPrefix() {
+        if (isBaseGroup()) {
+            return "";
+        } else if (prefix.isEmpty()) {
+            return name;
+        } else {
+            return prefix + "." + this.name;
+        }
+    }
+
+    @Inject
+    protected abstract ObjectFactory getObjects();
+
+    @Nested
+    public abstract ListProperty<BuildParameter> getParameters();
+
+    @Nested
+    public abstract ListProperty<BuildParameterGroup> getGroups();
+
+    @Input
+    public String getName() {
+        return name;
+    }
+
+    private boolean isBaseGroup() {
+        return BASE_GROUP_NAME.equals(name);
+    }
+}

--- a/src/main/java/de/jjohannes/gradle/buildparameters/BuildParametersExtension.java
+++ b/src/main/java/de/jjohannes/gradle/buildparameters/BuildParametersExtension.java
@@ -1,9 +1,6 @@
 package de.jjohannes.gradle.buildparameters;
 
-import org.gradle.api.Action;
-import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
 import org.gradle.plugin.devel.PluginDeclaration;
 
@@ -12,29 +9,21 @@ import javax.inject.Inject;
 import static de.jjohannes.gradle.buildparameters.Constants.PACKAGE_NAME;
 import static de.jjohannes.gradle.buildparameters.Constants.PLUGIN_CLASS_NAME;
 
-public abstract class BuildParametersExtension {
+public abstract class BuildParametersExtension extends BuildParameterGroup {
 
-    private final ObjectFactory objects;
     private final PluginDeclaration pluginDeclaration;
 
     @Inject
-    public BuildParametersExtension(Project project, GradlePluginDevelopmentExtension gradlePlugins) {
-        this.objects = project.getObjects();
+    public BuildParametersExtension(GradlePluginDevelopmentExtension gradlePlugins) {
+        // This name is used by the code generation
+        super(BuildParameterGroup.BASE_GROUP_NAME, "");
         this.pluginDeclaration = gradlePlugins.getPlugins().create("build-parameters", p -> {
             p.setId("build-parameters");
             p.setImplementationClass(PACKAGE_NAME + "." + PLUGIN_CLASS_NAME);
         });
     }
 
-    public void parameter(String name, Action<? super BuildParameter> configure) {
-        BuildParameter parameter = objects.newInstance(BuildParameter.class, name);
-        configure.execute(parameter);
-        getParameters().add(parameter);
-    }
-
     public void pluginId(String pluginId) {
         pluginDeclaration.setId(pluginId);
     }
-
-    public abstract ListProperty<BuildParameter> getParameters();
 }

--- a/src/main/java/de/jjohannes/gradle/buildparameters/BuildParametersPlugin.java
+++ b/src/main/java/de/jjohannes/gradle/buildparameters/BuildParametersPlugin.java
@@ -17,10 +17,10 @@ public class BuildParametersPlugin implements Plugin<Project> {
         GradlePluginDevelopmentExtension gradlePlugins =
                 project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
         BuildParametersExtension extension =
-                project.getExtensions().create("buildParameters", BuildParametersExtension.class, project, gradlePlugins);
+                project.getExtensions().create("buildParameters", BuildParametersExtension.class, gradlePlugins);
 
         TaskProvider<PluginCodeGeneration> task = project.getTasks().register("generatePluginCode", PluginCodeGeneration.class, it -> {
-            it.getParameters().convention(extension.getParameters());
+            it.getBaseGroup().convention(extension);
             it.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("generated/sources/build-parameters-plugin/java/main"));
         });
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);

--- a/src/main/java/de/jjohannes/gradle/buildparameters/CodeGeneratingBuildParameter.java
+++ b/src/main/java/de/jjohannes/gradle/buildparameters/CodeGeneratingBuildParameter.java
@@ -18,7 +18,7 @@ interface CodeGeneratingBuildParameter {
 
                 @Override
                 public String getValue() {
-                    return "providers.gradleProperty(\"" + parameter.getName() + "\").getOrElse(\"" + parameter.getDefaultValue().get() + "\")";
+                    return "providers.gradleProperty(\"" + parameter.getPath() + "\").getOrElse(\"" + parameter.getDefaultValue().get() + "\")";
                 }
 
                 @Override
@@ -35,7 +35,7 @@ interface CodeGeneratingBuildParameter {
 
                 @Override
                 public String getValue() {
-                    return "providers.gradleProperty(\"" + parameter.getName() + "\")";
+                    return "providers.gradleProperty(\"" + parameter.getPath() + "\")";
                 }
 
                 @Override

--- a/src/test/groovy/de/jjohannes/gradle/buildparameters/BuildParametersPluginFuncTest.groovy
+++ b/src/test/groovy/de/jjohannes/gradle/buildparameters/BuildParametersPluginFuncTest.groovy
@@ -72,6 +72,33 @@ class BuildParametersPluginFuncTest extends Specification {
         result.output.contains("myParameter: false")
     }
 
+    def "parameters can be grouped"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                group("db") {
+                    parameter("host") {
+                        defaultValue = "localhost"
+                    }
+                    parameter("port") {
+                        defaultValue = "5432"
+                    }
+                }
+            }
+        """
+        buildFile << """
+            println "db.host: " + buildParameters.db.host
+            println "db.port: " + buildParameters.db.port
+        """
+
+        when:
+        def result = build("help", "-Pdb.port=9999")
+
+        then:
+        result.output.contains("db.host: localhost")
+        result.output.contains("db.port: 9999")
+    }
+
     def "value of build parameters cannot be changed"() {
         given:
         buildLogicBuildFile << """
@@ -120,6 +147,5 @@ class BuildParametersPluginFuncTest extends Specification {
     // - Help task for descriptions
     // - Unknown parameter detection
     // - Different Parameter Types
-    // - Grouping
     // - Environment variable
 }


### PR DESCRIPTION
Introduces the `BuildParameterGroup` concept which can be used to group
related build parameters. This results in the groups parameters being
accessible under a common group prefix both when accessed in a build
script and when overridden on the command line.

As part of this the `BuildParametersExtension` now inherits from
`BuildParameterGroup` and there is some special handling to detect this
when a group or parameter is added. I think this part as well as the prefix
handling could be improved but I don't know how right now.