### PR TITLE
Add support for aliases for buildParameters

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -224,6 +224,36 @@ buildParameters {
 
 The group name will be used to namespace parameters when supplied via the command line and when accessing them in build scripts.
 
+
+=== Sourcing parameters from an alternate property name
+
+Parameters can be sourced from a different property name than the auto-generated one by using the `alias` method:
+
+```kotlin
+buildParameters {
+    group("myGroup") {
+        string("myString") {
+            alias("myGroup_myString")
+        }
+    }
+}
+```
+
+Multiple aliases can be specified
+
+```kotlin
+buildParameters {
+    group("myGroup") {
+        string("myString") {
+            alias("myGroup_myString")
+            alias("myStringFromMyGroup")
+        }
+    }
+}
+```
+
+The alias provides a fallback for the property source, so the original property value (`myGroup.myString`) can still be used as the source. The alias also does not change the buildParameter path (`buildParameters.myGroup.myString`).
+
 === Deriving parameter values from environment variables
 
 Sometimes you may want to supply a build parameter using the system environment.

--- a/src/main/java/org/gradlex/buildparameters/BuildParameter.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParameter.java
@@ -16,6 +16,7 @@
 
 package org.gradlex.buildparameters;
 
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -45,11 +46,19 @@ public abstract class BuildParameter<ParameterType> {
     @Optional
     public abstract Property<String> getEnvironmentVariableName();
 
+    @Input
+    @Optional
+    public abstract ListProperty<String> getAliases();
+
     public void fromEnvironment() {
         getEnvironmentVariableName().set("");
     }
 
     public void fromEnvironment(String variableName) {
         getEnvironmentVariableName().set(variableName);
+    }
+
+    public void alias(String alias) {
+        getAliases().add(alias);
     }
 }

--- a/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
+++ b/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
@@ -62,12 +62,32 @@ interface CodeGeneratingBuildParameter {
 
         @Override
         public String getValue() {
+            StringBuilder sb = new StringBuilder("providers.gradleProperty(\"")
+              .append(parameter.id.toPropertyPath())
+              .append("\")");
+
+            //Setup property alias fallback
+            for (String alias : parameter.getAliases().get()) {
+              sb.append(".orElse(providers.gradleProperty(\"")
+                .append(alias)
+                .append("\"))");
+            }
+
+            //Setup ENV variable fallback
             if (parameter.getEnvironmentVariableName().isPresent()) {
                 String envName = parameter.getEnvironmentVariableName().get();
                 envName = envName.isEmpty() ? parameter.id.toEnvironmentVariableName() : envName;
-                return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\").orElse(providers.environmentVariable(\"" + envName + "\"))" + type.transformation + ".getOrElse(" + getDefaultValue() + ")";
+                sb.append(".orElse(providers.environmentVariable(\"")
+                  .append(envName)
+                  .append("\"))");
             }
-            return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\")" + type.transformation + ".getOrElse(" + getDefaultValue() + ")";
+
+            sb.append(type.transformation)
+              .append(".getOrElse(")
+              .append(getDefaultValue())
+              .append(")");
+
+            return sb.toString();
         }
 
         private String getDefaultValue() {
@@ -96,13 +116,29 @@ interface CodeGeneratingBuildParameter {
 
         @Override
         public String getValue() {
+            StringBuilder sb = new StringBuilder("providers.gradleProperty(\"")
+              .append(parameter.id.toPropertyPath())
+              .append("\")");
+
+            //Setup property alias fallback
+            for (String alias : parameter.getAliases().get()) {
+              sb.append(".orElse(providers.gradleProperty(\"")
+                .append(alias)
+                .append("\"))");
+            }
+
+            //Setup ENV variable fallback
             if (parameter.getEnvironmentVariableName().isPresent()) {
                 String envName = parameter.getEnvironmentVariableName().get();
                 envName = envName.isEmpty() ? parameter.id.toEnvironmentVariableName() : envName;
-                return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\").orElse(providers.environmentVariable(\"" + envName + "\"))" + type.transformation;
-            } else {
-                return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\")" + type.transformation;
+                sb.append(".orElse(providers.environmentVariable(\"")
+                  .append(envName)
+                  .append("\"))");
             }
+
+            sb.append(type.transformation);
+
+            return sb.toString();
         }
 
         @Override

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
@@ -561,4 +561,44 @@ class BuildParametersPluginFuncTest extends Specification {
         result.output.contains("myBool: false")
         result.output.contains("myEnum: B")
     }
+
+    def "parameters can be given aliases to source from other property names"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                group("group") {
+                    string("myString") {
+                        alias("group_myString")
+                        alias("groupMyString")
+                    }
+                    integer("myInt") {
+                        alias("group_myInt")
+                    }
+                    bool("myBool") {
+                        alias("group_myBool")
+                    }
+                    enumeration("myEnum") {
+                        alias("group_myEnum")
+                        values = ['A', 'B']
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            println "myString: " + buildParameters.group.myString.get()
+            println "myInt: " + buildParameters.group.myInt.get()
+            println "myBool: " + buildParameters.group.myBool.get()
+            println "myEnum: " + buildParameters.group.myEnum.get()
+        """
+
+        when:
+        def result = build("help", "-PgroupMyString=Something", "-Pgroup_myInt=2", "-Pgroup_myBool=false", "-Pgroup_myEnum=B")
+
+        then:
+        result.output.contains("myString: Something")
+        result.output.contains("myInt: 2")
+        result.output.contains("myBool: false")
+        result.output.contains("myEnum: B")
+    }
 }


### PR DESCRIPTION
This adds the ability to source `buildParameters` from a different property than the default path generated by the property id as per #26 

One minor improvement would be the consolidation of the `getValue` logic into a shared underlying method. I've kept it separate for now as thats how it was before.



