### PR TITLE
Generate Settings Plugin

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -57,7 +57,7 @@ Use compile-safe accessor in your `settings.gradle(.kts)` (since 1.1):
 
 ```kotlin
 plugins {
-    id("build-parameters-settings")
+    id("build-parameters")
 }
 
 dependencyResolutionManagement {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -33,7 +33,7 @@ buildParameters {
 }
 ```
 
-Use compile-safe accessor in you build scripts to access parameter values:
+Use compile-safe accessor in your build scripts to access parameter values:
 
 ```kotlin
 plugins {
@@ -48,6 +48,28 @@ publishing {
             username = buildParameters.deployment.username
             // password does not have a default and is therefore of type Provider<String>
             password = buildParameters.deployment.password.get()
+        }
+    }
+}
+```
+
+Use compile-safe accessor in your `settings.gradle(.kts)` (since 1.1):
+
+```kotlin
+plugins {
+    id("build-parameters-settings")
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url = uri("https://repo.my-company.com")
+            credentials {
+                // username has a default and is therefore of type String
+                username = the<BuildParametersExtension>().deployment.username // Groovy DSL: buildParameters...
+                // password does not have a default and is therefore of type Provider<String>
+                password = the<BuildParametersExtension>().deployment.password.get() // Groovy DSL: buildParameters...
+            }
         }
     }
 }

--- a/src/main/java/org/gradlex/buildparameters/BuildParametersExtension.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParametersExtension.java
@@ -23,12 +23,10 @@ import javax.inject.Inject;
 
 import static org.gradlex.buildparameters.Constants.PACKAGE_NAME;
 import static org.gradlex.buildparameters.Constants.PLUGIN_CLASS_NAME;
-import static org.gradlex.buildparameters.Constants.SETTINGS_PLUGIN_CLASS_NAME;
 
 public abstract class BuildParametersExtension extends BuildParameterGroup {
 
     private final PluginDeclaration pluginDeclaration;
-    private final PluginDeclaration settingsPluginDeclaration;
 
     @Inject
     public BuildParametersExtension(GradlePluginDevelopmentExtension gradlePlugins) {
@@ -37,21 +35,14 @@ public abstract class BuildParametersExtension extends BuildParameterGroup {
             p.setId("build-parameters");
             p.setImplementationClass(PACKAGE_NAME + "." + PLUGIN_CLASS_NAME);
         });
-        this.settingsPluginDeclaration = gradlePlugins.getPlugins().create("build-parameters-settings", p -> {
-            p.setId("build-parameters-settings");
-            p.setImplementationClass(PACKAGE_NAME + "." + SETTINGS_PLUGIN_CLASS_NAME);
-        });
     }
 
     /**
-     * Configure the plugin IDs of the generated plugins.
-     * The project plugin ID will be 'pluginId' (the default is 'build-parameters').
-     * The settings plugin ID will be 'pluginId'-settings (the default is 'build-parameters-settings').
+     * Change the plugin ID of the generated plugin (the default is 'build-parameters').
      *
-     * @param pluginId The plugin ID for the generated plugins.
+     * @param pluginId The plugin ID for the generated plugin.
      */
     public void pluginId(String pluginId) {
         pluginDeclaration.setId(pluginId);
-        settingsPluginDeclaration.setId(pluginId + "-settings");
     }
 }

--- a/src/main/java/org/gradlex/buildparameters/BuildParametersExtension.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParametersExtension.java
@@ -23,10 +23,12 @@ import javax.inject.Inject;
 
 import static org.gradlex.buildparameters.Constants.PACKAGE_NAME;
 import static org.gradlex.buildparameters.Constants.PLUGIN_CLASS_NAME;
+import static org.gradlex.buildparameters.Constants.SETTINGS_PLUGIN_CLASS_NAME;
 
 public abstract class BuildParametersExtension extends BuildParameterGroup {
 
     private final PluginDeclaration pluginDeclaration;
+    private final PluginDeclaration settingsPluginDeclaration;
 
     @Inject
     public BuildParametersExtension(GradlePluginDevelopmentExtension gradlePlugins) {
@@ -35,9 +37,21 @@ public abstract class BuildParametersExtension extends BuildParameterGroup {
             p.setId("build-parameters");
             p.setImplementationClass(PACKAGE_NAME + "." + PLUGIN_CLASS_NAME);
         });
+        this.settingsPluginDeclaration = gradlePlugins.getPlugins().create("build-parameters-settings", p -> {
+            p.setId("build-parameters-settings");
+            p.setImplementationClass(PACKAGE_NAME + "." + SETTINGS_PLUGIN_CLASS_NAME);
+        });
     }
 
+    /**
+     * Configure the plugin IDs of the generated plugins.
+     * The project plugin ID will be 'pluginId' (the default is 'build-parameters').
+     * The settings plugin ID will be 'pluginId'-settings (the default is 'build-parameters-settings').
+     *
+     * @param pluginId The plugin ID for the generated plugins.
+     */
     public void pluginId(String pluginId) {
         pluginDeclaration.setId(pluginId);
+        settingsPluginDeclaration.setId(pluginId + "-settings");
     }
 }

--- a/src/main/java/org/gradlex/buildparameters/Constants.java
+++ b/src/main/java/org/gradlex/buildparameters/Constants.java
@@ -19,7 +19,6 @@ package org.gradlex.buildparameters;
 interface Constants {
     String PACKAGE_NAME = "buildparameters";
     String PLUGIN_CLASS_NAME = "GeneratedBuildParametersPlugin";
-    String SETTINGS_PLUGIN_CLASS_NAME = "GeneratedBuildParametersSettingsPlugin";
     String GENERATED_EXTENSION_NAME = "buildParameters";
     String GENERATED_EXTENSION_CLASS_NAME = "BuildParametersExtension";
 }

--- a/src/main/java/org/gradlex/buildparameters/Constants.java
+++ b/src/main/java/org/gradlex/buildparameters/Constants.java
@@ -19,4 +19,7 @@ package org.gradlex.buildparameters;
 interface Constants {
     String PACKAGE_NAME = "buildparameters";
     String PLUGIN_CLASS_NAME = "GeneratedBuildParametersPlugin";
+    String SETTINGS_PLUGIN_CLASS_NAME = "GeneratedBuildParametersSettingsPlugin";
+    String GENERATED_EXTENSION_NAME = "buildParameters";
+    String GENERATED_EXTENSION_CLASS_NAME = "BuildParametersExtension";
 }

--- a/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
+++ b/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
@@ -31,7 +31,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.gradlex.buildparameters.Constants.GENERATED_EXTENSION_CLASS_NAME;
+import static org.gradlex.buildparameters.Constants.GENERATED_EXTENSION_NAME;
 import static org.gradlex.buildparameters.Constants.PLUGIN_CLASS_NAME;
+import static org.gradlex.buildparameters.Constants.SETTINGS_PLUGIN_CLASS_NAME;
 import static org.gradlex.buildparameters.Strings.capitalize;
 import static java.util.stream.Collectors.toList;
 
@@ -57,10 +60,25 @@ public abstract class PluginCodeGeneration extends DefaultTask {
                 "import org.gradle.api.Project;",
                 "import org.gradle.api.Plugin;",
                 "",
-                "public class " + PLUGIN_CLASS_NAME + " implements Plugin<Project> {",
+                "public abstract class " + PLUGIN_CLASS_NAME + " implements Plugin<Project> {",
                 "    @Override",
                 "    public void apply(Project project) {",
-                "        project.getExtensions().create(\"buildParameters\", BuildParametersExtension.class);",
+                "        project.getExtensions().create(\"" + GENERATED_EXTENSION_NAME + "\", " + GENERATED_EXTENSION_CLASS_NAME + ".class);",
+                "    }",
+                "}"
+        ));
+
+        Path settingsPluginSource = getOutputDirectory().get().file(baseGroup.id.toPackageFolderPath() + "/" + SETTINGS_PLUGIN_CLASS_NAME + ".java").getAsFile().toPath();
+        write(settingsPluginSource, Arrays.asList(
+                "package " + baseGroup.id.toPackageName() + ";",
+                "",
+                "import org.gradle.api.Plugin;",
+                "import org.gradle.api.initialization.Settings;",
+                "",
+                "public abstract class " + SETTINGS_PLUGIN_CLASS_NAME + " implements Plugin<Settings> {",
+                "    @Override",
+                "    public void apply(Settings settings) {",
+                "        settings.getExtensions().create(\"" + GENERATED_EXTENSION_NAME + "\", " + GENERATED_EXTENSION_CLASS_NAME + ".class);",
                 "    }",
                 "}"
         ));

--- a/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
+++ b/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
@@ -34,7 +34,6 @@ import java.util.List;
 import static org.gradlex.buildparameters.Constants.GENERATED_EXTENSION_CLASS_NAME;
 import static org.gradlex.buildparameters.Constants.GENERATED_EXTENSION_NAME;
 import static org.gradlex.buildparameters.Constants.PLUGIN_CLASS_NAME;
-import static org.gradlex.buildparameters.Constants.SETTINGS_PLUGIN_CLASS_NAME;
 import static org.gradlex.buildparameters.Strings.capitalize;
 import static java.util.stream.Collectors.toList;
 
@@ -57,28 +56,13 @@ public abstract class PluginCodeGeneration extends DefaultTask {
         write(pluginSource, Arrays.asList(
                 "package " + baseGroup.id.toPackageName() + ";",
                 "",
-                "import org.gradle.api.Project;",
                 "import org.gradle.api.Plugin;",
+                "import org.gradle.api.plugins.ExtensionAware;",
                 "",
-                "public abstract class " + PLUGIN_CLASS_NAME + " implements Plugin<Project> {",
+                "public abstract class " + PLUGIN_CLASS_NAME + " implements Plugin<ExtensionAware> {",
                 "    @Override",
-                "    public void apply(Project project) {",
-                "        project.getExtensions().create(\"" + GENERATED_EXTENSION_NAME + "\", " + GENERATED_EXTENSION_CLASS_NAME + ".class);",
-                "    }",
-                "}"
-        ));
-
-        Path settingsPluginSource = getOutputDirectory().get().file(baseGroup.id.toPackageFolderPath() + "/" + SETTINGS_PLUGIN_CLASS_NAME + ".java").getAsFile().toPath();
-        write(settingsPluginSource, Arrays.asList(
-                "package " + baseGroup.id.toPackageName() + ";",
-                "",
-                "import org.gradle.api.Plugin;",
-                "import org.gradle.api.initialization.Settings;",
-                "",
-                "public abstract class " + SETTINGS_PLUGIN_CLASS_NAME + " implements Plugin<Settings> {",
-                "    @Override",
-                "    public void apply(Settings settings) {",
-                "        settings.getExtensions().create(\"" + GENERATED_EXTENSION_NAME + "\", " + GENERATED_EXTENSION_CLASS_NAME + ".class);",
+                "    public void apply(ExtensionAware projectOrSettings) {",
+                "        projectOrSettings.getExtensions().create(\"" + GENERATED_EXTENSION_NAME + "\", " + GENERATED_EXTENSION_CLASS_NAME + ".class);",
                 "    }",
                 "}"
         ));

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
@@ -39,7 +39,7 @@ class BuildParametersSettingsPluginFuncTest extends Specification {
                 includeBuild("build-logic")
             }
             plugins {
-                id 'build-parameters-settings'
+                id 'build-parameters'
             }
             buildParameters {}
         """
@@ -81,19 +81,6 @@ class BuildParametersSettingsPluginFuncTest extends Specification {
         result.output.contains("myInt: 99")
         result.output.contains("myBool: true")
         result.output.contains("myEnum: B")
-    }
-
-    def "plugin id of generated settings plugin can be configured"() {
-        given:
-        buildLogicBuildFile << """
-            buildParameters {
-                pluginId("org.example.build-params")
-            }
-        """
-        settingsFile.text = settingsFile.text.replace("build-parameters-settings", "org.example.build-params-settings")
-
-        expect:
-        build("help")
     }
 
 }

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlex.buildparameters
+
+import org.gradlex.buildparameters.fixture.GradleBuild
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class BuildParametersSettingsPluginFuncTest extends Specification {
+
+    @Delegate
+    @AutoCleanup
+    GradleBuild build = new GradleBuild()
+
+    File buildLogicBuildFile
+
+    def setup() {
+        buildLogicBuildFile = build.file("build-logic/build.gradle") << """
+            plugins {
+                id 'org.gradlex.build-parameters'
+            }
+        """
+        settingsFile << """
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+            plugins {
+                id 'build-parameters-settings'
+            }
+            buildParameters {}
+        """
+    }
+
+    def "supports reading build parameters in settings file"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                string("myString") {
+                    fromEnvironment()
+                    defaultValue = "default my string"
+                }
+                integer("myInt") {
+                    defaultValue = 99
+                }
+                bool("myBool") {
+                }
+                enumeration("myEnum") {
+                    values = ['A', 'B']
+                }
+            }
+        """
+        settingsFile << """
+            println "myString: " + buildParameters.myString
+            println "myInt: " + buildParameters.myInt
+            println "myBool: " + buildParameters.myBool.get()
+            println "myEnum: " + buildParameters.myEnum.get()
+        """
+
+        and:
+        environment.MYSTRING = "from env"
+
+        when:
+        def result = build("help", "-PmyBool=true", "-PmyEnum=B")
+
+        then:
+        result.output.contains("myString: from env")
+        result.output.contains("myInt: 99")
+        result.output.contains("myBool: true")
+        result.output.contains("myEnum: B")
+    }
+
+    def "plugin id of generated settings plugin can be configured"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                pluginId("org.example.build-params")
+            }
+        """
+        settingsFile.text = settingsFile.text.replace("build-parameters-settings", "org.example.build-params-settings")
+
+        expect:
+        build("help")
+    }
+
+}


### PR DESCRIPTION
Next to the "Project Plugin", which applies the generated Extension to a project (build file), this also generates a "Settings Plugin" that can be applied in the settings file to access build parameters there.

**Update:** In fact, we generate one plugin of type `Plugin<ExtensionAware>` that can be used in both Projects and Settings.

Resolves #24 

Note: In Kotlin DSL you have to do `the<BuildParametersExtension>` instead of just `buildParameters `. This is due to https://github.com/gradle/gradle/issues/11210 and should be solved in Gradle itself.