### PR TITLE
Explicitly pass constructor argument to Group objects

### DIFF
--- a/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
+++ b/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
@@ -98,7 +98,7 @@ public abstract class PluginCodeGeneration extends DefaultTask {
         lines.add("    @Inject");
         lines.add("    public " + groupClassName + "(ProviderFactory providers, ObjectFactory objects) {");
         for (BuildParameterGroup subGroup : subGroups) {
-            lines.add("        this." + subGroup.id.toFieldName() + " = objects.newInstance(" + subGroup.id.toFullQualifiedTypeName() + ".class);");
+            lines.add("        this." + subGroup.id.toFieldName() + " = objects.newInstance(" + subGroup.id.toFullQualifiedTypeName() + ".class, providers, objects);");
         }
         for (CodeGeneratingBuildParameter parameter : parameters) {
             lines.add("        this." + parameter.getId().toFieldName() + " = " + parameter.getValue() + ";");

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
@@ -243,14 +243,13 @@ class BuildParametersPluginFuncTest extends Specification {
                         defaultValue = "localhost"
                     }
                     string("port") {
-                        defaultValue = "5432"
                     }
                 }
             }
         """
         buildFile << """
             println "db.host: " + buildParameters.db.host
-            println "db.port: " + buildParameters.db.port
+            println "db.port: " + buildParameters.db.port.get()
         """
 
         when:

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersSettingsPluginFuncTest.groovy
@@ -83,4 +83,30 @@ class BuildParametersSettingsPluginFuncTest extends Specification {
         result.output.contains("myEnum: B")
     }
 
+    def "supports reading parameter groups in settings file"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                group("db") {
+                    string("host") {
+                        defaultValue = "localhost"
+                    }
+                    string("port") {
+                    }
+                }
+            }
+        """
+        settingsFile << """
+            println "db.host: " + buildParameters.db.host
+            println "db.port: " + buildParameters.db.port.get()
+        """
+
+        when:
+        def result = build("help", "-Pdb.port=9999")
+
+        then:
+        result.output.contains("db.host: localhost")
+        result.output.contains("db.port: 9999")
+    }
+
 }


### PR DESCRIPTION
The injection mechanism fails here in the context of settings files.

Fixes #43 