### PR TITLE
Allow defining parameters without configuration action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Build Parameters Gradle plugin - Changelog
 
 ## Version 1.2
+* [New] [#40](https://github.com/gradlex-org/build-parameters/issues/40) Allow defining parameters without configuration action
 * [Fixed] [#43](https://github.com/gradlex-org/build-parameters/issues/43) Parameter groups cannot be used in settings files
 
 ## Version 1.1

--- a/src/main/java/org/gradlex/buildparameters/BuildParameterGroup.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParameterGroup.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 
 public abstract class BuildParameterGroup {
 
+    private static final Action<Object> NO_OP = o -> {};
+
     final Identifier id;
 
     @Inject
@@ -33,12 +35,33 @@ public abstract class BuildParameterGroup {
         this.id = identifier;
     }
 
+    /**
+     * @since 1.2
+     */
+    public void string(String name) {
+        configureParameter(name, StringBuildParameter.class, NO_OP);
+    }
+
     public void string(String name, Action<? super BuildParameter<String>> configure) {
         configureParameter(name, StringBuildParameter.class, configure);
     }
 
+    /**
+     * @since 1.2
+     */
+    public void integer(String name) {
+        configureParameter(name, IntegerBuildParameter.class, NO_OP);
+    }
+
     public void integer(String name, Action<? super BuildParameter<Integer>> configure) {
         configureParameter(name, IntegerBuildParameter.class, configure);
+    }
+
+    /**
+     * @since 1.2
+     */
+    public void bool(String name) {
+        configureParameter(name, BooleanBuildParameter.class, NO_OP);
     }
 
     public void bool(String name, Action<? super BuildParameter<Boolean>> configure) {

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginFuncTest.groovy
@@ -18,6 +18,7 @@ package org.gradlex.buildparameters
 
 import org.gradlex.buildparameters.fixture.GradleBuild
 import spock.lang.AutoCleanup
+import spock.lang.Issue
 import spock.lang.Specification
 
 class BuildParametersPluginFuncTest extends Specification {
@@ -559,5 +560,25 @@ class BuildParametersPluginFuncTest extends Specification {
         result.output.contains("myInt: 2")
         result.output.contains("myBool: false")
         result.output.contains("myEnum: B")
+    }
+
+    @Issue("https://github.com/gradlex-org/build-parameters/issues/40")
+    def "parameters can be defined without configuration closure"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                string("myString")
+                integer("myInt")
+                bool("myBool")
+                group("myGroup") {
+                    string("myString")
+                    integer("myInt")
+                    bool("myBool")
+                }
+            }
+        """
+
+        expect:
+        build("help")
     }
 }


### PR DESCRIPTION
Add overloads for string, bool and integer parameters that allow
defining these parameter types without configuration action. For enum
parameters the list of values is mandatory so it makes no sense to add
an action-less overload here as well.

Resolves #40
