### PR TITLE
Boolean parameters: map '' to true and fail for unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Build Parameters Gradle plugin - Changelog
 
 ## Version 1.2
+* [New] [#42](https://github.com/gradlex-org/build-parameters/issues/42) Boolean parameters: empty string maps to 'true' and invalid value fails the build (instead of silently mapping to 'false')
 * [New] [#40](https://github.com/gradlex-org/build-parameters/issues/40) Allow defining parameters without configuration action
 * [Fixed] [#43](https://github.com/gradlex-org/build-parameters/issues/43) Parameter groups cannot be used in settings files
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -198,6 +198,10 @@ include::{samples-path}/defining-parameters/kotlin/gradle/plugins/build-paramete
 include::{samples-path}/defining-parameters/groovy/gradle/plugins/build-parameters/build.gradle[tags=boolean-parameter]
 ----
 
+Boolean parameters can only be set to 'true' or 'false'.
+The empty string is also mapped to 'true' so that `-Pmybool` is the same as `-Pmybool=true`.
+All other values will lead to an error during build configuration.
+
 ==== Enum parameters
 
 Use the `enumeration` method to define enumeration parameters.

--- a/src/docs/samples/defining-parameters/groovy/gradle/plugins/build-parameters/build.gradle
+++ b/src/docs/samples/defining-parameters/groovy/gradle/plugins/build-parameters/build.gradle
@@ -24,7 +24,7 @@ buildParameters {
 buildParameters {
     bool('mybool') {
         description = 'Optional description of the bool parameter'
-        defaultValue= true // optional
+        defaultValue = false // optional
     }
 }
 // end::boolean-parameter[]

--- a/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
+++ b/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
@@ -26,12 +26,12 @@ interface CodeGeneratingBuildParameter {
 
     Identifier getId();
 
-    static CodeGeneratingBuildParameter from(BuildParameter<?> parameter) {
+    static CodeGeneratingBuildParameter from(BuildParameter<?> parameter, BuildParameterGroup containingGroup) {
         ParameterType type;
         if (parameter instanceof IntegerBuildParameter) {
             type = new ParameterType("int", "Integer", ".map(Integer::parseInt)", Function.identity());
         } else if (parameter instanceof BooleanBuildParameter) {
-            type = new ParameterType("boolean", "Boolean", ".map(Boolean::parseBoolean)", Function.identity());
+            type = new ParameterType("boolean", "Boolean", ".map(" + containingGroup.id.toSimpleTypeName() + "::parse" + parameter.id.toSimpleTypeName() + ")", Function.identity());
         } else if (parameter instanceof EnumBuildParameter) {
             String typeName = parameter.id.toFullQualifiedTypeName();
             type = new ParameterType(typeName, typeName, ".map(" + typeName + "::valueOf)", s -> typeName + "." + s);


### PR DESCRIPTION
Boolean parameters can only be set to 'true' or 'false'. The empty string is also mapped to 'true' so that `-Pmybool` is the same as `-Pmybool=true`. All other values will lead to an error during build configuration.

Resolves #42 