### PR TITLE
Check for supported Gradle version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Build Parameters Gradle plugin - Changelog
 
+## Version 1.3
+* [New] [#18](https://github.com/gradlex-org/build-parameters/issues/18) Fail the build when it's running on an unsupported Gradle version
+
 ## Version 1.2
 * [New] [#42](https://github.com/gradlex-org/build-parameters/issues/42) Boolean parameters: empty string maps to 'true' and invalid value fails the build (instead of silently mapping to 'false')
 * [New] [#40](https://github.com/gradlex-org/build-parameters/issues/40) Allow defining parameters without configuration action

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Plugin%20Portal&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Forg%2Fgradlex%2Fbuild-parameters%2Forg.gradlex.build-parameters.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/org.gradlex.build-parameters)
 
 Compile-safe access to parameters supplied to a Gradle build.
+Compatible with Java 8 and Gradle 7.1 or later.
 
 # Primer
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,7 +9,7 @@ Based on this description it generates code for a plugin that can then be applie
 In that sense, the Build Parameters Gradle plugin is not a conventional plugin, but a meta plugin that you use to generate a plugin for your build.
 See the <<Setup>> section for more information on how to configure your build to use this plugin.
 
-Compatible with Java 8 and Gradle 7.0 or later. Earlier versions of Gradle may also work but compatibility is not tested.
+Compatible with Java 8 and Gradle 7.1 or later.
 
 == Primer
 

--- a/src/main/java/org/gradlex/buildparameters/BuildParametersPlugin.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParametersPlugin.java
@@ -23,11 +23,18 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin;
+import org.gradle.util.GradleVersion;
 
 public class BuildParametersPlugin implements Plugin<Project> {
 
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("7.1");
+
     @Override
     public void apply(Project project) {
+        if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION) < 0) {
+            throw new IllegalStateException("Plugin requires at least Gradle 7.1");
+        }
+
         project.getPlugins().apply(JavaGradlePluginPlugin.class);
 
         GradlePluginDevelopmentExtension gradlePlugins =

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
@@ -85,4 +85,14 @@ class BuildParametersPluginCrossVersionTest extends Specification {
         where:
         gradleVersion << ["7.1", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1"]
     }
+
+    def "fails the build on unsupported version"() {
+        when:
+        def result = runner("help")
+            .withGradleVersion("7.0.2")
+            .buildAndFail()
+
+        then:
+        result.output.contains("Plugin requires at least Gradle 7.1")
+    }
 }

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
@@ -1,0 +1,90 @@
+package org.gradlex.buildparameters
+
+import org.gradlex.buildparameters.fixture.GradleBuild
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class BuildParametersPluginCrossVersionTest extends Specification {
+
+    @Delegate
+    @AutoCleanup
+    GradleBuild build = new GradleBuild()
+
+    File buildLogicBuildFile
+
+    def setup() {
+        buildLogicBuildFile = build.file("build-logic/build.gradle") << """
+            plugins {
+                id 'org.gradlex.build-parameters'
+            }
+        """
+        settingsFile << """
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+        """
+        buildFile << """
+            plugins {
+                id 'build-parameters'
+            }
+        """
+    }
+
+    def "works on Gradle #gradleVersion"() {
+        given:
+        buildLogicBuildFile << """
+            buildParameters {
+                string("stringWithDefault") {
+                    defaultValue = "some value"
+                }
+                string("stringWithoutDefault")
+                integer("intWithDefault") {
+                    defaultValue = 1
+                }
+                integer("intWithoutDefault")
+                bool("booleanWithDefault") {
+                    defaultValue = true
+                }
+                bool("booleanWithoutDefault")
+                enumeration("enumWithDefault") {
+                    values = ["One", "Two", "Three"]
+                    defaultValue = "One"
+                }
+                enumeration("enumWithoutDefault") {
+                    values = ["One", "Two", "Three"]
+                }
+                group("group") {
+                    string("stringFromEnv") {
+                        fromEnvironment()
+                    }
+                }
+            }
+        """
+
+        and:
+        buildFile << """
+            println buildParameters.stringWithDefault
+            println buildParameters.stringWithoutDefault.get()
+            println buildParameters.intWithDefault
+            println buildParameters.intWithoutDefault.get()
+            println buildParameters.booleanWithDefault
+            println buildParameters.booleanWithoutDefault.get()
+            println buildParameters.enumWithDefault
+            println buildParameters.enumWithoutDefault.get()
+            println buildParameters.group.stringFromEnv.get()
+        """
+
+        and:
+        environment.GROUP_STRINGFROMENV = "Something from Env"
+
+        expect:
+        runner("help", "-PstringWithoutDefault=other", "-PintWithoutDefault=5", "-PbooleanWithoutDefault=true", "-PenumWithoutDefault=Two")
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        where:
+        gradleVersion << [
+                "6.2", "6.2.2", "6.3", "6.4.1", "6.5.1", "6.6.1", "6.7.1", "6.8.3", "6.9.2",
+                "7.0.2", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1"]
+    }
+}

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.buildparameters
 
 import org.gradlex.buildparameters.fixture.GradleBuild

--- a/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/BuildParametersPluginCrossVersionTest.groovy
@@ -83,8 +83,6 @@ class BuildParametersPluginCrossVersionTest extends Specification {
                 .build()
 
         where:
-        gradleVersion << [
-                "6.2", "6.2.2", "6.3", "6.4.1", "6.5.1", "6.6.1", "6.7.1", "6.8.3", "6.9.2",
-                "7.0.2", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1"]
+        gradleVersion << ["7.1", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1"]
     }
 }


### PR DESCRIPTION
The plugin now checks whether it's running on a supported Gradle version.
Only versions from Gradle 7.1 on wards are supported because previous versions
required calling `forUseAtConfigurationTime()` on providers that are resvoled
at configuration time. Later on that method was deprecated again. While it would
be possible to support older versions, it would lead to quite some complexity
in the generated plugin's code.

Currently only the generator plugin contains a version check, but not the
generated plugin. Since it's theoretically possible to publish the generated
plugin to a repository and then use it on an older Gradle version, there's
some potential for late runtime errors. So adding the check to the generated
plugin is a potential follow up improvement.

Last but not least this adds a cross version test as part of the default
test suite that verifies the plugin works on the minimum supported version
and the highest patch version for each Gradle minor release.

Resolves #17, #18