### PR TITLE
Simplify fromEnvironment handling

### DIFF
--- a/src/main/java/org/gradlex/buildparameters/BuildParameter.java
+++ b/src/main/java/org/gradlex/buildparameters/BuildParameter.java
@@ -49,7 +49,7 @@ public abstract class BuildParameter<ParameterType> {
     public abstract Property<String> getEnvironmentVariableName();
 
     public void fromEnvironment() {
-        getEnvironmentVariableName().set("");
+        getEnvironmentVariableName().set(id.toEnvironmentVariableName());
     }
 
     public void fromEnvironment(String variableName) {

--- a/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
+++ b/src/main/java/org/gradlex/buildparameters/CodeGeneratingBuildParameter.java
@@ -68,7 +68,6 @@ interface CodeGeneratingBuildParameter {
         public String getValue() {
             if (parameter.getEnvironmentVariableName().isPresent()) {
                 String envName = parameter.getEnvironmentVariableName().get();
-                envName = envName.isEmpty() ? parameter.id.toEnvironmentVariableName() : envName;
                 return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\").orElse(providers.environmentVariable(\"" + envName + "\"))" + type.transformation + ".getOrElse(" + getDefaultValue() + ")";
             }
             return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\")" + type.transformation + ".getOrElse(" + getDefaultValue() + ")";
@@ -107,7 +106,6 @@ interface CodeGeneratingBuildParameter {
         public String getValue() {
             if (parameter.getEnvironmentVariableName().isPresent()) {
                 String envName = parameter.getEnvironmentVariableName().get();
-                envName = envName.isEmpty() ? parameter.id.toEnvironmentVariableName() : envName;
                 return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\").orElse(providers.environmentVariable(\"" + envName + "\"))" + errorIfMandatory() + type.transformation;
             } else {
                 return "providers.gradleProperty(\"" + parameter.id.toPropertyPath() + "\")" + errorIfMandatory() + type.transformation;
@@ -132,7 +130,7 @@ interface CodeGeneratingBuildParameter {
             String description = parameter.getDescription().isPresent()
                     ? " (" + parameter.getDescription().get() + ")" : "";
             String envVariable = parameter.getEnvironmentVariableName().isPresent()
-                    ? "  " + environmentVariableName() + "=value (environment variable)\\n" : "";
+                    ? "  " + parameter.getEnvironmentVariableName().get() + "=value (environment variable)\\n" : "";
 
             return ".orElse(providers.provider(() -> { throw new RuntimeException(\"" +
                         "Build parameter " + parameter.id.toPropertyPath() + description + " not set. Use one of the following:\\n" +
@@ -140,12 +138,6 @@ interface CodeGeneratingBuildParameter {
                         "  " + parameter.id.toPropertyPath() + "=value (in 'gradle.properties' file)\\n" +
                         envVariable +
                     "\"); }))";
-        }
-
-        private String environmentVariableName() {
-            return parameter.getEnvironmentVariableName().get().isEmpty()
-                    ? parameter.id.toEnvironmentVariableName()
-                    : parameter.getEnvironmentVariableName().get();
         }
     }
 

--- a/src/main/java/org/gradlex/buildparameters/Parameters.java
+++ b/src/main/java/org/gradlex/buildparameters/Parameters.java
@@ -116,7 +116,6 @@ public abstract class Parameters extends DefaultTask {
 
             if (parameter.getEnvironmentVariableName().isPresent()) {
                 String envName = parameter.getEnvironmentVariableName().get();
-                envName = envName.isEmpty() ? parameter.id.toEnvironmentVariableName() : envName;
                 output.println("Environment Variable");
                 output.withStyle(Header).println("     " + envName);
                 output.println();

--- a/src/test/groovy/org/gradlex/buildparameters/ParametersTaskFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/ParametersTaskFuncTest.groovy
@@ -35,6 +35,7 @@ class ParametersTaskFuncTest extends Specification {
                     enumeration("baseBranch") {
                         values = ["bugfix", "hotfix", "integration", "main"]
                         defaultValue = "main"
+                        fromEnvironment("GITBRANCH")
                     }
                 }
             
@@ -141,7 +142,7 @@ class ParametersTaskFuncTest extends Specification {
         result.output.contains("Type\n     Enum")
         result.output.contains("Values\n     bugfix, hotfix, integration, main")
         result.output.contains("Default value\n     main")
-        !result.output.contains("Environment Variable")
+        result.output.contains("Environment Variable\n     GITBRANCH")
         result.output.contains("Examples\n     -Pgitflow.baseBranch=bugfix")
     }
 }


### PR DESCRIPTION
Instead of using an empty string to indicate the auto-generated
environment variable name should be used, we now set the aut-generated
name directly as a property value.

Fixes #70
