### PR TITLE
Set the minimum logging level that will fail the task to WARNING

### DIFF
--- a/gradle/plugins/documentation-conventions/src/main/kotlin/gradlexbuild.asciidoctor-conventions.gradle.kts
+++ b/gradle/plugins/documentation-conventions/src/main/kotlin/gradlexbuild.asciidoctor-conventions.gradle.kts
@@ -6,6 +6,8 @@ tasks {
     asciidoctor {
         notCompatibleWithConfigurationCache("See https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/564")
 
+        failureLevel = Severity.WARN
+
         attributes(mapOf(
             "docinfodir" to "src/docs/asciidoc",
             "docinfo" to "shared",

--- a/gradle/plugins/documentation-conventions/src/main/kotlin/gradlexbuild.asciidoctor-conventions.gradle.kts
+++ b/gradle/plugins/documentation-conventions/src/main/kotlin/gradlexbuild.asciidoctor-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import org.asciidoctor.gradle.base.log.Severity
+
 plugins {
     id("org.asciidoctor.jvm.convert")
 }


### PR DESCRIPTION
This will need to be re-executed after https://github.com/gradlex-org/build-parameters/pull/83 which contains a fix that removes warnings.