### PR TITLE
An Enum's toString() method returns the un-escaped value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.4.3
 * [Fixed] [#100](https://github.com/gradlex-org/build-parameters/issues/100) Parameter validation ignores parameters from the `org.gralde` namespace
+* [Fixed] [#93](https://github.com/gradlex-org/build-parameters/issues/93) Generated Enum's `toString()` method returns the un-escaped value
 
 ## Version 1.4.2
 * [Fixed] [#87](https://github.com/gradlex-org/build-parameters/issues/87) Code generation is locale sensitive and generates invalid code on some locales

--- a/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
+++ b/src/main/java/org/gradlex/buildparameters/PluginCodeGeneration.java
@@ -224,6 +224,17 @@ public abstract class PluginCodeGeneration extends DefaultTask {
         }
         lines.add("        return " + typeName + ".valueOf(value);");
         lines.add("    }");
+        lines.add("");
+        lines.add("    @Override");
+        lines.add("    public String toString() {");
+        for (String enumValue : values) {
+            String escapedValue = escapeEnumValue(enumValue);
+            if (!enumValue.equals(escapedValue)) {
+                lines.add("        if (this == " + escapedValue + ") return \"" + enumValue + "\";");
+            }
+        }
+        lines.add("        return name();");
+        lines.add("    }");
     }
 
     private void generateBooleanParseMethod(BooleanBuildParameter p, List<String> lines) {

--- a/src/test/groovy/org/gradlex/buildparameters/EnumValuesFuncTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/EnumValuesFuncTest.groovy
@@ -63,6 +63,16 @@ class EnumValuesFuncTest extends Specification {
             assert buildParameters.enumParam == buildparameters.EnumParam._super
             // if the value is an allowed identifier, it is not escaped
             assert buildParameters.enumParam != buildparameters.EnumParam.not_a_keyword
+            
+            // using the enum value "as String" you get the original (non-escapen) value
+            assert buildparameters.EnumParam._super.toString() == 'super'
+            assert "" + buildparameters.EnumParam._super == 'super'
+            assert buildparameters.EnumParam._enum.toString() == 'enum'
+            assert "" + buildparameters.EnumParam._enum == 'enum'
+            assert buildparameters.EnumParam._int.toString() == 'int'
+            assert "" + buildparameters.EnumParam._int == 'int'
+            assert buildparameters.EnumParam.not_a_keyword.toString() == 'not_a_keyword'
+            assert "" + buildparameters.EnumParam.not_a_keyword == 'not_a_keyword'      
         """
 
         expect:


### PR DESCRIPTION
Resolves #93 