### PR TITLE
Configure rootProject name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 import buildparameters.BuildParametersExtension
 
+rootProject.name = "build-parameters"
+
 pluginManagement {
     includeBuild("gradle/plugins") {
         name = "build-parameters-gradle-plugins"


### PR DESCRIPTION
Otherwise it is defined by the project's checkout directory name which
may be different from 'build-parameters' depending on how the project
was cloned (e.g. on CI).
