### PR TITLE
Reduce cross-version test combiantions

### DIFF
--- a/src/test/groovy/org/gradlex/buildparameters/GradleCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradlex/buildparameters/GradleCrossVersionTest.groovy
@@ -99,7 +99,7 @@ class GradleCrossVersionTest extends Specification {
                 .build()
 
         where:
-        gradleVersion << ["7.1", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1", "7.6.1"]
+        gradleVersion << ["7.1.1", "7.6.1", "8.0.1", "8.2-rc-2"]
     }
 
     def "fails the build on unsupported version"() {


### PR DESCRIPTION
Instead of testing each minor release, only the first and last minor
release of each major release line are tested.
