### PR TITLE
Capture dependency graph on GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,19 @@
+name: Dependency Submission
+
+on: [ push ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.1.0
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3.0.0
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-service-agree: "yes"


### PR DESCRIPTION
Adds a workflow for running the gradle/actions/dependency-submission
action on each push, which will fill the dependency graph on GitHub and
report vulnerable dependencies. Workflow implementation follows
recommendation from https://github.com/gradle/actions/blob/main/dependency-submission/README.md
