### PR TITLE
Upgrade vulnerable dependencies using constraints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,16 +13,8 @@ java {
 }
 
 dependencies.constraints {
-    checkstyle("com.google.guava:guava") {
-        version {
-            require("33.3.1-jre")
-        }
-    }
-    testSamplesImplementation("commons-io:commons-io") {
-        version {
-            require("2.18.0")
-        }
-    }
+    checkstyle("com.google.guava:guava:33.3.1-jre")
+    testSamplesImplementation("commons-io:commons-io:2.18.0")
 }
 
 pluginPublishConventions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,19 @@ java {
     toolchain.languageVersion = JavaLanguageVersion.of(8)
 }
 
+dependencies.constraints {
+    checkstyle("com.google.guava:guava") {
+        version {
+            require("33.3.1-jre")
+        }
+    }
+    testSamplesImplementation("commons-io:commons-io") {
+        version {
+            require("2.18.0")
+        }
+    }
+}
+
 pluginPublishConventions {
     id("${project.group}.${project.name}")
     implementationClass("org.gradlex.buildparameters.BuildParametersPlugin")


### PR DESCRIPTION
There are four security related dependabot alerts reported against this
project, two coming from a transative Guava dependency that is pulled in
via Checkstyle and two coming from commons-io which is pulled in by
exemplar. None of these alerts could affect consumer builds that apply
this plugin, because the vulnerable dependencies are only used at build
time. This pull request defined version constraints to upgrade both
vulnerable dependencies to their latest versions, that way fixing the
dependabot alerts.
