### PR TITLE
chore: use centralized renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    'github>gradlex-org/renovate-config'
+  ]
+}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,11 +10,11 @@ jobs:
   gradle-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.5.0
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.2.0
       - uses: testlens-app/setup-testlens@v1.9.3
       - run: "./gradlew :check"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -9,8 +9,8 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: gradle/actions/dependency-submission@v6
+      - uses: actions/checkout@v7.0.0
+      - uses: gradle/actions/dependency-submission@v6.2.0
         with:
           build-scan-publish: true
           build-scan-terms-of-use-url: https://gradle.com/terms-of-service

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,19 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/configure-pages@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/configure-pages@v6.0.0
+      - uses: actions/setup-java@v5.5.0
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.2.0
         with:
           build-scan-terms-of-use-url: https://gradle.com/terms-of-service
           build-scan-terms-of-use-agree: yes
       - uses: testlens-app/setup-testlens@v1.9.3
       - run: "./gradlew asciidoctorAll"
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: "./build/docs/asciidoc/html"
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ jobs:
   release-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-java@v5.5.0
         with:
           distribution: zulu
           java-version: 17
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.2.0
         with:
           build-scan-terms-of-use-url: https://gradle.com/terms-of-service
           build-scan-terms-of-use-agree: yes

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
References https://github.com/gradlex-org/renovate-config so we can
change renovate defaults for all repositories in a central place.
Uses json5 syntax which is easier to write than JSON, see
https://json5.org/.